### PR TITLE
Add SwiftUI MusicKit sample app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Xcode build artifacts
+.DS_Store
+.build
+DerivedData

--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # SpatMusic
-SpatMusic is your new Music player!
+
+SpatMusic is an experimental music player built with SwiftUI and MusicKit. The goal is to provide a clean interface that addresses many of the common UI criticisms directed at Apple Music.
+
+## Key Design Improvements
+
+- **Minimal tabs** – only Library, Search and Now Playing to reduce clutter.
+- **Clear library sorting** – easily change sort order by title, artist or album.
+- **Quick access to the queue** – see upcoming songs directly in the Now Playing screen.
+- **Focus on your library** – avoid distracting recommendations by default.
+
+See the [SpatMusicApp](SpatMusicApp/README.md) directory for the Swift package containing the sample code.

--- a/SpatMusicApp/Package.swift
+++ b/SpatMusicApp/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version:5.5
+import PackageDescription
+
+let package = Package(
+    name: "SpatMusicApp",
+    platforms: [.iOS(.v15)],
+    products: [
+        .executable(name: "SpatMusicApp", targets: ["SpatMusicApp"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/madmachiney/MusicKit", from: "1.0.0")
+    ],
+    targets: [
+        .executableTarget(
+            name: "SpatMusicApp",
+            dependencies: ["MusicKit"],
+            path: "Sources/SpatMusicApp")
+    ]
+)

--- a/SpatMusicApp/README.md
+++ b/SpatMusicApp/README.md
@@ -1,0 +1,9 @@
+# SpatMusicApp
+
+This is a simple MusicKit based example written in SwiftUI. It demonstrates a simplified user interface that addresses common complaints about Apple Music's design:
+
+- **Simpler tab layout** with Library, Search and Now Playing only
+- **Easier library sorting** via a sort picker
+- **Accessible queue view** in the Now Playing screen
+
+The project uses Swift Package Manager. To build open the folder in Xcode 15 or later and run on an iOS 15+ device.

--- a/SpatMusicApp/Sources/SpatMusicApp/ContentView.swift
+++ b/SpatMusicApp/Sources/SpatMusicApp/ContentView.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+import MusicKit
+
+struct ContentView: View {
+    var body: some View {
+        TabView {
+            LibraryView()
+                .tabItem {
+                    Label("Library", systemImage: "music.note.list")
+                }
+            SearchView()
+                .tabItem {
+                    Label("Search", systemImage: "magnifyingglass")
+                }
+            NowPlayingView()
+                .tabItem {
+                    Label("Now Playing", systemImage: "play.circle")
+                }
+        }
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/SpatMusicApp/Sources/SpatMusicApp/LibraryView.swift
+++ b/SpatMusicApp/Sources/SpatMusicApp/LibraryView.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+import MusicKit
+
+struct LibraryView: View {
+    @State private var musicAuthorization: MusicAuthorization.Status = .notDetermined
+    @State private var librarySongs: [Song] = []
+    @State private var sortOrder: SortOrder = .title
+
+    enum SortOrder: String, CaseIterable, Identifiable {
+        case title, artist, album
+        var id: String { rawValue }
+        var descriptor: MusicCatalogSearchableAttribute {
+            switch self {
+            case .title: return .title
+            case .artist: return .artistName
+            case .album: return .albumTitle
+            }
+        }
+    }
+
+    var body: some View {
+        NavigationView {
+            Group {
+                if librarySongs.isEmpty {
+                    Text("No Music")
+                } else {
+                    List(librarySongs) { song in
+                        VStack(alignment: .leading) {
+                            Text(song.title)
+                                .font(.headline)
+                            Text(song.artistName)
+                                .font(.subheadline)
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Library")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Menu {
+                        Picker("Sort", selection: $sortOrder) {
+                            ForEach(SortOrder.allCases) { order in
+                                Text(order.rawValue.capitalized).tag(order)
+                            }
+                        }
+                    } label: {
+                        Label("Sort", systemImage: "arrow.up.arrow.down")
+                    }
+                }
+            }
+        }
+        .task(id: sortOrder) {
+            await loadLibrary()
+        }
+    }
+
+    func loadLibrary() async {
+        if musicAuthorization != .authorized {
+            musicAuthorization = await MusicAuthorization.request()
+        }
+        guard musicAuthorization == .authorized else { return }
+        var request = MusicLibraryRequest<Song>()
+        request.sort(by: sortOrder.descriptor, ascending: true)
+        do {
+            let response = try await request.response()
+            librarySongs = response.items
+        } catch {
+            print("Failed to load library: \(error)")
+        }
+    }
+}

--- a/SpatMusicApp/Sources/SpatMusicApp/NowPlayingView.swift
+++ b/SpatMusicApp/Sources/SpatMusicApp/NowPlayingView.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+import MusicKit
+
+struct NowPlayingView: View {
+    @Environment(MusicPlayer.self) private var player
+    @State private var nowPlayingItem: Song?
+    @State private var queue: MusicPlayer.Queue?
+
+    var body: some View {
+        VStack {
+            if let song = nowPlayingItem {
+                VStack {
+                    Text(song.title)
+                        .font(.title)
+                    Text(song.artistName)
+                        .font(.headline)
+                }
+                .padding()
+            }
+            if let queue = queue {
+                List(queue.entries, id: \._entryID) { entry in
+                    VStack(alignment: .leading) {
+                        Text(entry.item.title)
+                        Text(entry.item.artistName)
+                            .font(.subheadline)
+                    }
+                }
+            } else {
+                Text("Queue empty")
+            }
+        }
+        .onAppear(perform: updatePlayerInfo)
+        .navigationTitle("Now Playing")
+    }
+
+    func updatePlayerInfo() {
+        nowPlayingItem = player.nowPlayingItem as? Song
+        queue = player.queue
+    }
+}

--- a/SpatMusicApp/Sources/SpatMusicApp/SearchView.swift
+++ b/SpatMusicApp/Sources/SpatMusicApp/SearchView.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+import MusicKit
+
+struct SearchView: View {
+    @State private var query: String = ""
+    @State private var searchResults: MusicCatalogSearchResponse<Song>?
+
+    var body: some View {
+        NavigationView {
+            VStack {
+                TextField("Search songs", text: $query)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                    .padding()
+                if let songs = searchResults?.songs, !songs.isEmpty {
+                    List(songs) { song in
+                        VStack(alignment: .leading) {
+                            Text(song.title)
+                                .font(.headline)
+                            Text(song.artistName)
+                                .font(.subheadline)
+                        }
+                    }
+                } else {
+                    Spacer()
+                    Text("No results")
+                    Spacer()
+                }
+            }
+            .navigationTitle("Search")
+        }
+        .searchable(text: $query)
+        .onSubmit(of: .search) {
+            Task { await performSearch() }
+        }
+    }
+
+    func performSearch() async {
+        do {
+            let request = MusicCatalogSearchRequest(term: query, types: [Song.self])
+            searchResults = try await request.response()
+        } catch {
+            print("Search failed: \(error)")
+        }
+    }
+}

--- a/SpatMusicApp/Sources/SpatMusicApp/SpatMusicApp.swift
+++ b/SpatMusicApp/Sources/SpatMusicApp/SpatMusicApp.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+import MusicKit
+
+@main
+struct SpatMusicApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create Swift Package with simple MusicKit-based app
- show simplified UI with Library, Search and Now Playing
- update README to outline design improvements

## Testing
- `swift package describe`
- `swift build` *(fails: could not fetch dependency due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_68459e7fc6688327849648ceb8ff9ca3